### PR TITLE
Bugfix/address multi file model inheritance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- [Bugfix] Fix issue where model field parsing logic didn't account for Django models that inherited from other models (not models.Model)
+- [Bugfix] Fix issue where model field parsing logic didn't account for Django models that inherited from other models (not models.Model). This update required that we cache model parents during the initial scan so that we could trace the inheritance chain through multiple files.
 
 
 ## [Version 0.1.10] - 2024-08-23

--- a/server/src/providers/django/djangoProvider.ts
+++ b/server/src/providers/django/djangoProvider.ts
@@ -462,7 +462,7 @@ export class DjangoProvider extends LanguageProvider {
         );
         const parserFilePath = path.join(basePath, 'django_parser.py');
 
-        console.log(`[DEBUG] Resolved parser file path: ${parserFilePath}`);
+        console.log(`Resolved parser file path: ${parserFilePath}`);
     
         return parserFilePath;
     }


### PR DESCRIPTION
### Summary of Tracing Model Parents in Multi-File Inheritance

In the updated setup, we trace model parents by recursively inspecting the inheritance chain to determine if a class, either directly or through its parents, inherits from `models.Model`. This is necessary to handle cases where models extend custom base classes defined in other files.

#### Steps in the Updated Logic:

1. **Direct Check for `models.Model`**: 
   - The parser first checks if the class directly inherits from `models.Model`. If it does, the class is immediately recognized as a Django model.

2. **Recursive Parent Class Check**:
   - If the class inherits from a custom base class (e.g., `TimeStampedModel`), the parser looks up the cached information for that class to retrieve its parent models.
   - The parser then recursively checks the retrieved parent models to see if any of them eventually inherit from `models.Model`.

3. **Handling Multi-File Inheritance**:
   - This recursive tracing is crucial in multi-file setups where models might inherit from custom base classes that are defined in separate files. By tracing the parent classes across multiple files, we can accurately determine if a model is part of the Django model hierarchy, even if its immediate parent is not `models.Model`.

#### Why We Needed This Change:

In Django projects, especially larger ones, it's common for models to extend custom base classes defined in other files. Without recursively tracing the inheritance chain across files, models like `FlatFileTransfer`, which extend `TimeStampedModel`, would not be correctly identified as Django models because the direct inheritance from `models.Model` is abstracted away in the base class.

This recursive approach ensures that models are properly recognized as Django models, even when their parent classes are split across multiple files, solving the multi-file model inheritance problem.
