### PR TITLE
Feature/flag redundant queryset methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Version 0.1.16] - 2024-09-11
+## [Version 0.1.16] - 2024-09-12
+
+### Added
+
+- [Feature] Add rule CDQ14 that flags redundant queryset method chains like `all().filter()` or `all().count()`. 
 
 ### Changed
 

--- a/server/bundled/tools/python/checks/redundant_queryset_methods/checker.py
+++ b/server/bundled/tools/python/checks/redundant_queryset_methods/checker.py
@@ -1,0 +1,82 @@
+import ast
+from log import LOGGER
+from .constants import RedundantQueryMethodIssue
+
+
+class RedundantQueryMethodCheckService:
+    def __init__(self, source_code: str):
+        self.source_code = source_code
+        self.lines = self.source_code.splitlines()
+
+    def get_method_chain(self, node):
+        """Recursively get the method chain from a call node."""
+        chain = []
+        while isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+            chain.append(node.func.attr)
+            node = node.func.value
+        return chain
+
+    def is_redundant_queryset_chain(self, method_chain):
+        """Check if the method chain contains redundant queryset patterns."""
+        return method_chain in [
+            ['count', 'all'],
+            ['exists', 'filter'],
+            ['count', 'filter'],
+            ['first', 'filter'],
+            ['last', 'filter']
+        ]
+
+    def get_end_col_offset(self, node):
+        """Get the end column offset of the method chain."""
+        if hasattr(node, 'end_col_offset'):
+            return node.end_col_offset
+        source_line = self.source_code.splitlines()[node.lineno - 1]
+        return node.col_offset + len(source_line) - node.col_offset
+
+    def get_fixed_queryset(self, original_query, method_chain, simplified_chain):
+        """
+        Replace the redundant part of the query (method_chain) with the simplified_chain
+        and return the fixed queryset.
+        
+        Note: The method_chain is reversed, so we will replace the first instance of the redundant method
+        """
+        fixed_query = original_query.replace(".".join(method_chain), simplified_chain, 1)
+        return fixed_query
+
+    def run_check(self, node: ast.AST) -> RedundantQueryMethodIssue:
+        """Run the redundant query method check on the given AST node."""
+        LOGGER.info("Running redundant query method check")
+        try:
+            for current_node in ast.walk(node):
+                if isinstance(current_node, ast.Call):
+                    method_chain = self.get_method_chain(current_node)
+                    if self.is_redundant_queryset_chain(method_chain):
+                        original_query = self.lines[current_node.lineno - 1]
+                        simplified_chain = self.get_simplified_chain(method_chain)
+                        fixed_queryset = self.get_fixed_queryset(original_query, method_chain, simplified_chain)
+
+                        issue = RedundantQueryMethodIssue(
+                            method_chain=".".join(reversed(method_chain)),
+                            simplified_chain=simplified_chain,
+                            lineno=current_node.lineno,
+                            col_offset=current_node.col_offset,
+                            end_col_offset=self.get_end_col_offset(current_node),
+                            fixed_queryset=fixed_queryset,
+                        )
+                        return issue
+            return None
+        except Exception as e:
+            LOGGER.warning(f"Error while running redundant query method check: {e}")
+            return None
+
+    def get_simplified_chain(self, method_chain):
+        """Get the simplified method chain based on the redundant pattern."""
+        if method_chain == ['count', 'all']:
+            return 'count()'
+        if method_chain == ['exists', 'filter']:
+            return 'exists()'
+        if method_chain == ['first', 'filter']:
+            return 'first()'
+        if method_chain == ['last', 'filter']:
+            return 'last()'
+        return None

--- a/server/bundled/tools/python/checks/redundant_queryset_methods/checker.py
+++ b/server/bundled/tools/python/checks/redundant_queryset_methods/checker.py
@@ -20,10 +20,8 @@ class RedundantQueryMethodCheckService:
         """Check if the method chain contains redundant queryset patterns."""
         return method_chain in [
             ['count', 'all'],
-            ['exists', 'filter'],
-            ['count', 'filter'],
-            ['first', 'filter'],
-            ['last', 'filter']
+            ['all', 'filter'],
+            ['filter', 'all'],
         ]
 
     def get_end_col_offset(self, node):
@@ -73,10 +71,6 @@ class RedundantQueryMethodCheckService:
         """Get the simplified method chain based on the redundant pattern."""
         if method_chain == ['count', 'all']:
             return 'count()'
-        if method_chain == ['exists', 'filter']:
-            return 'exists()'
-        if method_chain == ['first', 'filter']:
-            return 'first()'
-        if method_chain == ['last', 'filter']:
-            return 'last()'
+        if method_chain == ['all', 'filter'] or method_chain == ['filter', 'all']:
+            return 'filter()'
         return None

--- a/server/bundled/tools/python/checks/redundant_queryset_methods/constants.py
+++ b/server/bundled/tools/python/checks/redundant_queryset_methods/constants.py
@@ -42,4 +42,4 @@ class RedundantQueryMethodIssue(Issue):
 
     @property
     def doc_link(self):
-        return IssueDocLinks.RAW_SQL_USAGE  # TODO: change this to a relevant link
+        return IssueDocLinks.QUERYSET_API

--- a/server/bundled/tools/python/checks/redundant_queryset_methods/constants.py
+++ b/server/bundled/tools/python/checks/redundant_queryset_methods/constants.py
@@ -1,0 +1,45 @@
+from issue import Issue, IssueSeverity, IssueDocLinks
+
+class RedundantQueryMethodIssue(Issue):
+    code = 'CDQ14'
+    description = (
+        'Redundant QuerySet method chain detected: "{method_chain}"\n\n'
+        'The current chain of methods is unnecessary because the final method "{simplified_chain}" already provides the desired result.\n\n'
+        'Consider replacing "{method_chain}" with "{simplified_chain}"\n\n'
+        'Simplified queries avoid redundant operations, resulting in cleaner and easier-to-maintain code.'
+    )
+
+    def __init__(
+        self,
+        method_chain,
+        simplified_chain,
+        lineno,
+        col_offset,
+        end_col_offset,
+        fixed_queryset,
+        severity=IssueSeverity.INFORMATION
+    ):
+        formatted_method_chain = self.format_method_chain(method_chain)
+        self.method_chain = method_chain
+        self.simplified_chain = simplified_chain
+        self.col_offset = col_offset
+        self.end_col_offset = end_col_offset
+        self.fixed_queryset = fixed_queryset
+
+        parameters = {
+            'method_chain': formatted_method_chain,
+            'simplified_chain': simplified_chain,
+            'severity': severity,
+        }
+        super().__init__(lineno, col_offset, parameters)
+
+    def format_method_chain(self, method_chain):
+        """
+        Format the method chain to include '()' after each method, e.g., 'all().count()'
+        """
+        methods = method_chain.split(".")
+        return ".".join([f"{method}()" for method in methods])
+
+    @property
+    def doc_link(self):
+        return IssueDocLinks.RAW_SQL_USAGE  # TODO: change this to a relevant link

--- a/server/bundled/tools/python/issue.py
+++ b/server/bundled/tools/python/issue.py
@@ -15,6 +15,7 @@ class IssueDocLinks:
     X_FRAME_OPTIONS = 'https://docs.djangoproject.com/en/5.0/ref/clickjacking/'
     SECURE_HSTS_SECONDS = 'https://docs.djangoproject.com/en/5.0/ref/settings/#secure-hsts-seconds'
     SECURE_HSTS_INCLUDE_SUBDOMAINS = 'https://docs.djangoproject.com/en/5.0/ref/settings/#secure-hsts-include-subdomains'
+    QUERYSET_API = 'https://docs.djangoproject.com/en/5.0/ref/models/querysets/'
 
 
 class Issue(object):

--- a/server/bundled/tools/python/tests/test_redundant_queryset_methods.py
+++ b/server/bundled/tools/python/tests/test_redundant_queryset_methods.py
@@ -1,0 +1,77 @@
+# server/bundled/tools/python/tests/test_redundant_queryset_methods.py
+import ast
+import unittest
+import textwrap
+from unittest.mock import patch
+
+from checks.redundant_queryset_methods.checker import RedundantQueryMethodCheckService
+from issue import IssueSeverity
+
+class TestRedundantQueryMethodCheckService(unittest.TestCase):
+
+    @patch('log.LOGGER')
+    def test_redundant_queryset_count_all_detected(self, mock_logger):
+        source_code = textwrap.dedent("""
+            def get_customer_count():
+                return Customer.objects.all().count()
+        """)
+        service = RedundantQueryMethodCheckService(source_code)
+        tree = ast.parse(source_code)
+        
+        issue = service.run_check(tree)
+        
+        self.assertIsNotNone(issue)
+        self.assertEqual(issue.method_chain, "all.count")
+        self.assertEqual(issue.simplified_chain, "count()")
+        self.assertEqual(issue.severity, IssueSeverity.INFORMATION)
+        self.assertIn("Redundant QuerySet method chain detected", issue.message)
+        self.assertIn("Consider replacing", issue.message)
+        self.assertIn("count()", issue.fixed_queryset)
+
+    @patch('log.LOGGER')
+    def test_non_redundant_queryset_not_detected(self, mock_logger):
+        source_code = textwrap.dedent("""
+            def get_customer():
+                return Customer.objects.get(id=1)
+        """)
+        service = RedundantQueryMethodCheckService(source_code)
+        tree = ast.parse(source_code)
+        
+        issue = service.run_check(tree)
+        
+        self.assertIsNone(issue)
+
+    @patch('log.LOGGER')
+    def test_all_filter_redundancy_detected(self, mock_logger):
+        source_code = textwrap.dedent("""
+        def get_active_customers():
+            return Customer.objects.all().filter(is_active=True)
+        """)
+        service = RedundantQueryMethodCheckService(source_code)
+        tree = ast.parse(source_code)
+        
+        issue = service.run_check(tree)
+        print("issue", issue)
+        
+        self.assertIsNotNone(issue)
+        self.assertEqual(issue.code, 'CDQ14')
+        self.assertEqual(issue.severity, IssueSeverity.INFORMATION)
+        self.assertIn('Redundant QuerySet method chain detected', issue.message)
+        self.assertIn('Consider replacing "all().filter()" with "filter()"', issue.message)
+
+    @patch('log.LOGGER')
+    def test_filter_not_redundant(self, mock_logger):
+        source_code = textwrap.dedent("""
+        def get_active_customers():
+            return Customer.objects.filter(is_active=True)
+        """)
+        service = RedundantQueryMethodCheckService(source_code)
+        tree = ast.parse(source_code)
+        
+        issue = service.run_check(tree)
+        
+        self.assertIsNone(issue)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/server/bundled/tools/python/tests/test_redundant_queryset_methods.py
+++ b/server/bundled/tools/python/tests/test_redundant_queryset_methods.py
@@ -1,4 +1,3 @@
-# server/bundled/tools/python/tests/test_redundant_queryset_methods.py
 import ast
 import unittest
 import textwrap

--- a/server/src/constants/rules.ts
+++ b/server/src/constants/rules.ts
@@ -57,6 +57,7 @@ export enum RuleCodes {
     DJANGO_FIELD_CONVENTIONS = "CDQ11",
     COMMENT_VALIDATION = "CDQ12",
     CELERY_TASK_VALIDATION = "CDQ13", // TODO: custom rule. Might move to own category
+    REDUNDANT_QUERYSET_METHODS = "CDQ14",
 
     // Style-related rules (STY)
     BOOLEAN_VARIABLE_PREFIX = "STY01",

--- a/server/src/providers/django/djangoProvider.ts
+++ b/server/src/providers/django/djangoProvider.ts
@@ -363,6 +363,10 @@ export class DjangoProvider extends LanguageProvider {
         let result: any;
 
         switch (type) {
+            case RuleCodes.REDUNDANT_QUERYSET_METHODS:
+                this.processRedundantQuerysetMethod(symbol, diagnostics);
+                return; // skip general diagnostic creation for queryset methods
+
             case "function":
             case "django_model_method":
             case "django_serializer_method":
@@ -995,4 +999,21 @@ export class DjangoProvider extends LanguageProvider {
 			timestamp: new Date().toISOString()
 		});
 	}
+
+    private processRedundantQuerysetMethod(symbol: any, diagnostics: Diagnostic[]): void {
+        const range = Range.create(
+            Position.create(symbol.line - 1, symbol.col_offset),
+            Position.create(symbol.line - 1, symbol.end_col_offset)
+        );
+
+        const mappedSeverity = this.mapSeverity(symbol.severity);
+        const diagnostic = this.diagnosticsManager.createDiagnostic(
+            range,
+            symbol.message,
+            mappedSeverity,
+            RuleCodes.REDUNDANT_QUERYSET_METHODS
+        );
+    
+        diagnostics.push(diagnostic);
+    }    
 }

--- a/server/src/services/diagnostics/diagnosticsManager.ts
+++ b/server/src/services/diagnostics/diagnosticsManager.ts
@@ -62,16 +62,20 @@ export class DiagnosticsManager {
         range: Range,
         message: string,
         severity: DiagnosticSeverity,
-        sourceType = NAMING_CONVENTION_VIOLATION_SOURCE_TYPE
+        sourceType = NAMING_CONVENTION_VIOLATION_SOURCE_TYPE,
+        linkToReferenceDocs: string = ""
     ): Diagnostic {
-        // TODO: create link to more information based on sourcetype and message
-        return Diagnostic.create(
+        const diagnostic: Diagnostic = {
             range,
             message,
             severity,
-            sourceType,
-            SOURCE_NAME
-        );
+            source: SOURCE_NAME,
+            code: sourceType,
+            codeDescription: {
+                href: linkToReferenceDocs
+            }
+        };
+        return diagnostic;
     }
 
 	public isDiagnosticCached(documentUri: string): boolean {


### PR DESCRIPTION
## In This PR
<!-- Please provide a brief description of the change being made -->
- Add rule CDQ14 that flags redundant queryset method chains like `all().filter()` or `all().count()`. 

### Related Issue(s)
<!-- If this pull request addresses one or more issues, link them here. Example:
Closes #123 -->

