### PR TITLE
Bugfix/ensure correct id is used for cached api key

### DIFF
--- a/client/src/common/auth/authService.ts
+++ b/client/src/common/auth/authService.ts
@@ -98,8 +98,6 @@ export class AuthService {
             if (migrationResult) {
                 await this.context.globalState.update(SESSION_TOKEN_KEY, apiKeySession.token);
                 await this.context.globalState.update(SESSION_USER, apiKeySession);
-                // clear legacy api key to prevent it from being used again
-                await this.context.globalState.update(COMMANDS.USER_API_KEY, undefined);
             }
 
             return migrationResult;

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -16,7 +16,7 @@ export const API_SERVER_URL = process.env.NODE_ENV === "development" ?  "http://
 export const GITHUB_CLIENT_ID = process.env.NODE_ENV === "development" ? "Ov23li4Egp5QaJKU3ftO" : "Ov23liV8A8SgrWwMhFwI";
 
 export const COMMANDS = {
-    USER_API_KEY: `${EXTENSION_NAME}.userApiKey`,
+    USER_API_KEY: `${EXTENSION_NAME}.apiKey`,
     GITHUB_OAUTH_CALLBACK: `${EXTENSION_NAME}.githubOauthCallback`,
     SIGN_IN: `${EXTENSION_NAME}.signIn`,
     GITHUB_SIGN_IN: `${EXTENSION_NAME}.githubSignIn`,


### PR DESCRIPTION
## In This PR
<!-- Please provide a brief description of the change being made -->
- Addresses an issue where the legacy API key was always undefined; thus, the migration prompt never showed. This was caused by using the wrong context cache key.
- Ensure logs in client github auths service class are surfaced.
